### PR TITLE
fix: pronoun vi changed from subst to pron

### DIFF
--- a/treebanks/Norwegian-NynorskLIA/aal_uio_06.conll
+++ b/treebanks/Norwegian-NynorskLIA/aal_uio_06.conll
@@ -218,7 +218,7 @@
 5	nokre	nokon	det		fl|kvant	6	DET		hov
 6	geiter	geit	subst		fem|fl|appell|ub	2	KOORD		hov
 7	hadde	ha	verb		pret	0	FINV		hov
-8	vi	vi	subst		fl|hum|1|nom	7	SUBJ		hov
+8	vi	vi	pron		fl|hum|1|nom	7	SUBJ		hov
 9	der	der	prep			7	ADV		hov
 10	#	#	pause			11	IK		hov
 11	til	til	prep			7	ADV		hov


### PR DESCRIPTION
In the process of converting the LIA Nynorsk treebank to the universal dependencies annotations, I discovered an odd occurrence of "vi" tagged with part-of-speech tag `subst` rather than `pron`. This pull request changes it to `pron`. 